### PR TITLE
Fix API data fetch and CLI stop-sell

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -77,7 +77,7 @@ def stop_sell(symbol, qty, stop_price):
     result = submit_order(symbol, qty, 'sell', 'stop', stop_price=stop_price)
     click.echo(result)
 
-    save_order_if_valid(result, 'sell', fallback_price=limit_price)
+    save_order_if_valid(result, 'sell', fallback_price=stop_price)
 
 @cli.command()
 def positions():

--- a/trading_app/finnhub_client.py
+++ b/trading_app/finnhub_client.py
@@ -17,13 +17,14 @@ def get_finnhub_bars(symbol, resolution=60, count=24):
     Get recent OHLCV bars (default: last 96 x 15min bars = 24 hours).
     Returns a DataFrame with timestamp index and open/high/low/close/volume.
     """
-    end = int((datetime.now()  - timedelta(minutes=60)).timestamp())
+    # Finnhub's API requires UNIX timestamps for the start and end range.
+    # We request `count` bars ending at the current time minus one hour to
+    # avoid incomplete data for the most recent candle.
+    end = int((datetime.now() - timedelta(minutes=60)).timestamp())
     start = end - (int(resolution) * 60 * count)
-    resolution = "D"
-    start = "1738655051"
-    end = "1738741451"
+
     url = (
-        f"https://finnhub.io/api/v1/stock/candle"
+        "https://finnhub.io/api/v1/stock/candle"
         f"?symbol={symbol}&resolution={resolution}&from={start}&to={end}&token={FINNHUB_API_KEY}"
     )
 


### PR DESCRIPTION
## Summary
- correct calculation of date range in `get_finnhub_bars`
- fix typo in CLI stop-loss command

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688a89c5fe188328b1de7952ff135d83