### PR TITLE
Remove docker compose from deployment script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,4 +28,3 @@ jobs:
           key: ${{ secrets.DO_SSH_KEY }}
           script: |
             cd /home/${{ secrets.DO_USER }}/app
-            docker-compose up --build -d


### PR DESCRIPTION
## Summary
- stop launching the container in `.github/workflows/deploy.yml`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688a9ba34fa08328a6503951b042c204