### PR TITLE
Add daily scheduler framework

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -134,5 +134,13 @@ def predict_symbol(symbol):
     predict(symbol.upper())
 
 
+@cli.command()
+def run_scheduler():
+    """Run scheduled tasks defined in trading_app.tasks."""
+    from trading_app.scheduler import run
+    click.echo("Starting scheduler... Press Ctrl+C to exit.")
+    run()
+
+
 if __name__ == '__main__':
     cli()

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,4 @@ numpy==1.24.4
 xgboost
 scikit-learn
 joblib
-
-
-
+schedule>=1.2.0

--- a/trading_app/scheduler.py
+++ b/trading_app/scheduler.py
@@ -1,0 +1,32 @@
+import time
+import schedule
+
+# Holds tuples of (time_string, function, args, kwargs)
+registered_tasks = []
+
+def daily(time_str):
+    """Decorator to register a function to run daily at the given time."""
+    def decorator(func):
+        registered_tasks.append((time_str, func, [], {}))
+        return func
+    return decorator
+
+def add_daily_task(time_str, func, *args, **kwargs):
+    """Programmatically register a daily task."""
+    registered_tasks.append((time_str, func, args, kwargs))
+
+
+def _setup():
+    """Internal: schedule all registered tasks."""
+    for time_str, func, args, kwargs in registered_tasks:
+        schedule.every().day.at(time_str).do(func, *args, **kwargs)
+
+
+def run():
+    """Run the scheduler loop."""
+    # Import tasks to ensure decorators are executed
+    import trading_app.tasks  # noqa: F401
+    _setup()
+    while True:
+        schedule.run_pending()
+        time.sleep(1)

--- a/trading_app/tasks.py
+++ b/trading_app/tasks.py
@@ -1,0 +1,7 @@
+from trading_app.scheduler import daily
+from trading_app.data.collect_data import fetch_all
+
+@daily("14:00")
+def collect_history_data():
+    """Fetch historical data for configured symbols."""
+    fetch_all()


### PR DESCRIPTION
## Summary
- add simple schedule-based framework to register daily tasks
- create first scheduled job to collect daily history data at 2pm
- expose new `run_scheduler` CLI command
- include `schedule` library in requirements

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688b07ad51588328b37409d97d427264