### PR TITLE
Add supervisor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,19 @@ FROM python:3.10-slim
 # Set work directory
 WORKDIR /app
 
+# Install supervisor for process management
+RUN apt-get update \ 
+    && apt-get install -y supervisor \ 
+    && rm -rf /var/lib/apt/lists/*
+
 # Copy app code
 COPY . .
 
-# Install dependencies
+# Install Python dependencies
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Default command (override for different CLI args)
-CMD ["python", "cli.py"]
+# Add Supervisor configuration
+COPY supervisord.conf /etc/supervisor/conf.d/trading_app.conf
+
+# Run Supervisor in foreground so container stays alive
+CMD ["supervisord", "-n"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - .env
     depends_on:
       - mysql
-    entrypoint: bash
+    command: ["supervisord", "-n"]
     stdin_open: true
     tty: true
 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,7 @@
+[program:trading_app]
+command=python /app/cli.py run_scheduler
+directory=/app
+autostart=true
+autorestart=true
+stderr_logfile=/dev/stderr
+stdout_logfile=/dev/stdout


### PR DESCRIPTION
## Summary
- install and configure Supervisor
- run the scheduler with Supervisor so it automatically restarts

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688b0cfc6f2c832882b06c0c962182c9