### PR TITLE
Add Alpaca WebSocket streaming

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3,6 +3,7 @@ from trading_app.alpaca_client import get_latest_price
 from trading_app.finnhub_client import get_finnhub_quote
 from trading_app import init_app
 from trading_app.helpers import save_order_if_valid
+from trading_app.alpaca_client import stream_live_data
 
 init_app()
 
@@ -132,6 +133,13 @@ def predict_symbol(symbol):
     """Predict if the given symbol will go UP or DOWN using the latest model."""
     from trading_app.ml.predict_symbol import predict_symbol as predict
     predict(symbol.upper())
+
+
+@cli.command()
+@click.argument('symbol')
+def stream(symbol):
+    """Print live trade updates for the given symbol."""
+    stream_live_data(symbol)
 
 
 @cli.command()

--- a/trading_app/alpaca_client.py
+++ b/trading_app/alpaca_client.py
@@ -1,4 +1,6 @@
 from alpaca_trade_api.rest import REST, TimeFrame
+from alpaca_trade_api.stream import Stream
+import asyncio
 from .config import ALPACA_API_KEY, ALPACA_SECRET_KEY, ALPACA_BASE_URL
 
 alpaca = REST(ALPACA_API_KEY, ALPACA_SECRET_KEY, ALPACA_BASE_URL)
@@ -87,3 +89,29 @@ def get_historical_data(symbol, start, end, timeframe=TimeFrame.Minute):
     except Exception as e:
         print(f"[Alpaca Error] {e}")
         return None
+
+
+def stream_live_data(symbol, data_type="trades"):
+    """Subscribe to live Alpaca data for a symbol using WebSockets."""
+
+    async def _run():
+        stream = Stream(
+            ALPACA_API_KEY,
+            ALPACA_SECRET_KEY,
+            base_url=ALPACA_BASE_URL,
+            data_feed="iex",
+        )
+
+        if data_type == "trades":
+            stream.subscribe_trades(handler, symbol)
+        elif data_type == "quotes":
+            stream.subscribe_quotes(handler, symbol)
+        else:
+            stream.subscribe_bars(handler, symbol)
+
+        await stream._run_forever()
+
+    def handler(data):
+        print(data)
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- add Alpaca websocket streaming helper and CLI command
- allow running `colada stream SYMBOL` to watch live trades

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d22fe1a908328b918bfab732a97a0