### PR TITLE
Add reusable TA calculator

### DIFF
--- a/trading_app/data/collect_data.py
+++ b/trading_app/data/collect_data.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 import os
 import pandas as pd
 from trading_app.alpaca_client import get_historical_data
+from trading_app.indicators import TACalculator
 
 SYMBOLS = ["AAPL", "GOOG", "MSFT"]
 OUTPUT_DIR = "data"
@@ -26,6 +27,9 @@ def fetch_data(symbol):
         "close": "last",
         "volume": "sum"
     }).dropna()
+
+    # Add common technical indicators
+    df_15 = TACalculator.add_indicators(df_15)
 
     os.makedirs(OUTPUT_DIR, exist_ok=True)
     df_15.to_csv(f"{OUTPUT_DIR}/{symbol}_15min.csv")

--- a/trading_app/data/prepare_dataset.py
+++ b/trading_app/data/prepare_dataset.py
@@ -1,6 +1,7 @@
 import os
 import pandas as pd
 import pandas_ta as ta
+from trading_app.indicators import TACalculator
 
 INPUT_DIR = "data"
 OUTPUT_DIR = "features"
@@ -15,10 +16,11 @@ def prepare_features(symbol):
     df = pd.read_csv(path, index_col=0, parse_dates=True)
 
     # Add technical indicators
+    df = TACalculator.add_indicators(df)
     df["return"] = df["close"].pct_change()
     df["ma5"] = df["close"].rolling(5).mean()
     df["ma20"] = df["close"].rolling(20).mean()
-    df["rsi"] = ta.rsi(df["close"], length=14)
+    df["rsi"] = df["rsi_14"]
 
     # Drop rows with NaN
     df = df.dropna()

--- a/trading_app/indicators.py
+++ b/trading_app/indicators.py
@@ -1,0 +1,26 @@
+import pandas as pd
+import pandas_ta as ta
+
+
+class TACalculator:
+    """Utility class for adding common technical indicators."""
+
+    @staticmethod
+    def add_indicators(bars: pd.DataFrame, close_col: str = "close") -> pd.DataFrame:
+        """Return a copy of ``bars`` with basic technical indicators added."""
+        if close_col not in bars.columns:
+            raise ValueError(f"'{close_col}' column not found in DataFrame")
+
+        df = bars.copy()
+        df["rsi_14"] = ta.rsi(df[close_col], length=14)
+
+        macd = ta.macd(df[close_col], fast=12, slow=26)
+        if isinstance(macd, pd.DataFrame):
+            df["macd"] = macd["MACD_12_26_9"]
+            df["macd_signal"] = macd["MACDs_12_26_9"]
+            df["macd_hist"] = macd["MACDh_12_26_9"]
+
+        df["sma_20"] = df[close_col].rolling(20).mean()
+        df["volatility"] = df[close_col].rolling(20).std()
+
+        return df

--- a/trading_app/ml/predict_symbol.py
+++ b/trading_app/ml/predict_symbol.py
@@ -4,6 +4,7 @@ from joblib import load
 from datetime import datetime
 from trading_app.finnhub_client import get_finnhub_bars
 import pandas_ta as ta
+from trading_app.indicators import TACalculator
 
 def load_model(symbol):
     model_path = f"models/model_{symbol}.pkl"
@@ -18,10 +19,11 @@ def prepare_latest_features(symbol):
         print(f"No data for {symbol}")
         return None
 
+    df = TACalculator.add_indicators(df)
     df["return"] = df["close"].pct_change()
     df["ma5"] = df["close"].rolling(5).mean()
     df["ma20"] = df["close"].rolling(20).mean()
-    df["rsi"] = ta.rsi(df["close"], length=14)
+    df["rsi"] = df["rsi_14"]
 
     df = df.dropna()
     if df.empty:


### PR DESCRIPTION
## Summary
- implement `TACalculator` helper for common indicators
- add indicators to Alpaca-collected data
- reuse helper when preparing datasets and building prediction features

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688d2679fa8c8328a2240321d7747023