### PR TITLE
Add market hours check using Alpaca clock

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -39,8 +39,12 @@ def buy(symbol, qty):
     """Place a market buy order."""
     from trading_app.alpaca_client import submit_market_order
     result = submit_market_order(symbol, qty, 'buy')
-    click.echo(result)
 
+    if isinstance(result, dict) and 'error' in result:
+        click.echo(f"Error: {result['error']}")
+        return
+
+    click.echo(result)
     save_order_if_valid(result, 'buy')
 
 
@@ -51,8 +55,12 @@ def sell(symbol, qty):
     """Place a market sell order."""
     from trading_app.alpaca_client import submit_market_order
     result = submit_market_order(symbol, qty, 'sell')
-    click.echo(result)
 
+    if isinstance(result, dict) and 'error' in result:
+        click.echo(f"Error: {result['error']}")
+        return
+
+    click.echo(result)
     save_order_if_valid(result, 'sell')
 
 @cli.command()
@@ -63,8 +71,12 @@ def limit_buy(symbol, qty, limit_price):
     """Place a limit buy order."""
     from trading_app.alpaca_client import submit_order
     result = submit_order(symbol, qty, 'buy', 'limit', limit_price=limit_price)
-    click.echo(result)
 
+    if isinstance(result, dict) and 'error' in result:
+        click.echo(f"Error: {result['error']}")
+        return
+
+    click.echo(result)
     save_order_if_valid(result, 'buy', fallback_price=limit_price)
 
 
@@ -76,8 +88,12 @@ def stop_sell(symbol, qty, stop_price):
     """Place a stop-loss sell order."""
     from trading_app.alpaca_client import submit_order
     result = submit_order(symbol, qty, 'sell', 'stop', stop_price=stop_price)
-    click.echo(result)
 
+    if isinstance(result, dict) and 'error' in result:
+        click.echo(f"Error: {result['error']}")
+        return
+
+    click.echo(result)
     save_order_if_valid(result, 'sell', fallback_price=stop_price)
 
 @cli.command()
@@ -108,6 +124,15 @@ def balance():
         click.echo(f"Buying Power:    ${summary['buying_power']}")
         click.echo(f"Portfolio Value: ${summary['portfolio_value']}")
         click.echo(f"Account Status:  {summary['status']}")
+
+
+@cli.command()
+def market_status():
+    """Show whether the market is currently open."""
+    from trading_app.alpaca_client import is_market_open
+
+    status = "open" if is_market_open() else "closed"
+    click.echo(f"Market is currently {status}.")
 
 @cli.command()
 def collect_data():

--- a/trading_app/alpaca_client.py
+++ b/trading_app/alpaca_client.py
@@ -5,6 +5,16 @@ from .config import ALPACA_API_KEY, ALPACA_SECRET_KEY, ALPACA_BASE_URL
 
 alpaca = REST(ALPACA_API_KEY, ALPACA_SECRET_KEY, ALPACA_BASE_URL)
 
+
+def is_market_open() -> bool:
+    """Return True if the market is currently open."""
+    try:
+        clock = alpaca.get_clock()
+        return bool(getattr(clock, "is_open", False))
+    except Exception as e:
+        print(f"[Alpaca Error] {e}")
+        return False
+
 def get_latest_price(symbol):
     barset = alpaca.get_bars(symbol, TimeFrame.Minute, limit=1)
     return barset[-1].c if barset else None
@@ -14,6 +24,8 @@ def submit_market_order(symbol, qty, side):
     Places a market order to buy or sell a given symbol.
     side: 'buy' or 'sell'
     """
+    if not is_market_open():
+        return {"error": "Market is closed"}
     try:
         order = alpaca.submit_order(
             symbol=symbol,
@@ -36,6 +48,8 @@ def submit_order(symbol, qty, side, order_type='market', limit_price=None, stop_
     :param limit_price: used for 'limit' orders
     :param stop_price: used for 'stop' orders
     """
+    if not is_market_open():
+        return {"error": "Market is closed"}
     try:
         order = alpaca.submit_order(
             symbol=symbol,


### PR DESCRIPTION
## Summary
- add `is_market_open` helper in `alpaca_client`
- block order placement when market is closed
- handle order errors in CLI
- add `market_status` CLI command

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688d28ff198c83288a2f8d8c05226daf