### PR TITLE
refactor: fix sentiment timestamp and clean dataset scripts

### DIFF
--- a/trading_app/data/collect_data.py
+++ b/trading_app/data/collect_data.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timedelta
 import os
-import pandas as pd
 from trading_app.alpaca_client import get_historical_data
 from trading_app.indicators import TACalculator
 
@@ -8,8 +7,10 @@ SYMBOLS = ["AAPL", "GOOG", "MSFT"]
 OUTPUT_DIR = "data"
 DAYS = 30
 
+
 def fetch_data(symbol):
-    start = (datetime.now() - timedelta(days=31)).strftime("%Y-%m-%d")
+    """Download recent data for ``symbol`` and store a 15-minute file."""
+    start = (datetime.now() - timedelta(days=DAYS + 1)).strftime("%Y-%m-%d")
     end = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
 
     print(f"Getting data for {symbol} from: {start} and {end}")

--- a/trading_app/data/create_sentiment_dataset.py
+++ b/trading_app/data/create_sentiment_dataset.py
@@ -35,7 +35,7 @@ def fetch_news_sentiment(symbol: str) -> pd.Series:
     analyzer = SentimentAnalyzer()
     rows = []
     for item in news_items:
-        ts = item.get("providerPublishTime") or item.get("providerPublishTime")
+        ts = item.get("providerPublishTime") or item.get("publishTime")
         if ts is None:
             continue
         ts = pd.to_datetime(ts, unit="s")

--- a/trading_app/data/prepare_dataset.py
+++ b/trading_app/data/prepare_dataset.py
@@ -1,6 +1,5 @@
 import os
 import pandas as pd
-import pandas_ta as ta
 from trading_app.indicators import TACalculator
 
 INPUT_DIR = "data"
@@ -21,9 +20,10 @@ def prepare_features(symbol):
     df["ma5"] = df["close"].rolling(5).mean()
     df["ma20"] = df["close"].rolling(20).mean()
     df["rsi"] = df["rsi_14"]
+    df.drop(columns=["rsi_14"], inplace=True)
 
     # Drop rows with NaN
-    df = df.dropna()
+    df.dropna(inplace=True)
 
     # Create target: 1 if next close is higher than current close
     df["target"] = (df["close"].shift(-1) > df["close"]).astype(int)


### PR DESCRIPTION
## Summary
- Improve `collect_data` to rely on configured window and drop unused import
- Clean up dataset preparation by dropping extra RSI column
- Fix sentiment dataset builder to handle alternate news timestamps

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688da981418883288d72511514987ed1