### PR TITLE
Add backtesting module scaffolding

### DIFF
--- a/backtest/__init__.py
+++ b/backtest/__init__.py
@@ -1,0 +1,12 @@
+"""Backtesting module scaffolding."""
+
+from .backtest_engine import BacktestEngine
+from .trade_simulator import TradeSimulator
+from .metrics import calculate_metrics, plot_performance
+
+__all__ = [
+    "BacktestEngine",
+    "TradeSimulator",
+    "calculate_metrics",
+    "plot_performance",
+]

--- a/backtest/backtest_engine.py
+++ b/backtest/backtest_engine.py
@@ -1,0 +1,28 @@
+"""Core backtesting engine."""
+from __future__ import annotations
+
+import pandas as pd
+
+from .trade_simulator import TradeSimulator
+from .metrics import calculate_metrics, plot_performance
+
+
+class BacktestEngine:
+    """Coordinate trade simulations and metric calculations."""
+
+    def __init__(self, data: pd.DataFrame, initial_cash: float = 10_000.0) -> None:
+        self.data = data
+        self.simulator = TradeSimulator(initial_cash=initial_cash)
+        self.results: pd.DataFrame | None = None
+        self.metrics: pd.DataFrame | None = None
+
+    def run(self, signals: pd.Series) -> pd.DataFrame:
+        """Execute a backtest given trading signals."""
+        self.results = self.simulator.simulate(self.data, signals)
+        self.metrics = calculate_metrics(self.results)
+        return self.results
+
+    def plot(self) -> None:
+        """Plot performance metrics if available."""
+        if self.metrics is not None:
+            plot_performance(self.metrics)

--- a/backtest/metrics.py
+++ b/backtest/metrics.py
@@ -1,0 +1,29 @@
+"""Performance metrics and plotting utilities."""
+from __future__ import annotations
+
+import pandas as pd
+
+try:
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover
+    plt = None
+
+
+def calculate_metrics(portfolio: pd.DataFrame) -> pd.DataFrame:
+    """Compute simple performance metrics from a portfolio DataFrame."""
+    metrics = pd.DataFrame(index=portfolio.index)
+    metrics["cumulative_return"] = (
+        portfolio["portfolio_value"].pct_change().fillna(0).add(1).cumprod() - 1
+    )
+    return metrics
+
+
+def plot_performance(metrics: pd.DataFrame) -> None:
+    """Plot cumulative return using matplotlib if available."""
+    if plt is None or metrics.empty:
+        return
+    ax = metrics["cumulative_return"].plot(title="Cumulative Return")
+    ax.set_xlabel("Time")
+    ax.set_ylabel("Return")
+    plt.tight_layout()
+    plt.show()

--- a/backtest/trade_simulator.py
+++ b/backtest/trade_simulator.py
@@ -1,0 +1,20 @@
+"""Simple trade simulator stub."""
+from __future__ import annotations
+
+import pandas as pd
+
+
+class TradeSimulator:
+    """Simulate trades based on signals."""
+
+    def __init__(self, initial_cash: float = 10_000.0) -> None:
+        self.initial_cash = initial_cash
+
+    def simulate(self, data: pd.DataFrame, signals: pd.Series) -> pd.DataFrame:
+        """Generate portfolio values from price data and signals."""
+        portfolio = pd.DataFrame(index=data.index)
+        portfolio["cash"] = self.initial_cash
+        portfolio["position"] = signals.fillna(0)
+        # Placeholder for actual trade execution logic
+        portfolio["portfolio_value"] = portfolio["cash"]
+        return portfolio


### PR DESCRIPTION
## Summary
- scaffold backtesting engine coordinating trade simulation and metrics
- provide reusable trade simulator and metrics utilities with optional plotting

## Testing
- `python -m py_compile backtest/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688dabb2447c83288eaeb7ffb928cd13