### PR TITLE
Add execution cost modelling to trade simulator

### DIFF
--- a/backtest/trade_simulator.py
+++ b/backtest/trade_simulator.py
@@ -1,5 +1,7 @@
-"""Simple trade simulator stub."""
+"""Simple trade simulator with rudimentary execution costs."""
 from __future__ import annotations
+
+import random
 
 import pandas as pd
 
@@ -13,12 +15,43 @@ class TradeSimulator:
     tests and demonstrations.
     """
 
-    def __init__(self, initial_cash: float = 10_000.0) -> None:
+    def __init__(
+        self,
+        initial_cash: float = 10_000.0,
+        commission_per_share: float = 0.005,
+        commission_per_trade: float = 1.0,
+        spread: float = 0.0,
+        spread_pct: float = 0.0,
+    ) -> None:
         self.initial_cash = initial_cash
+        self.cash = initial_cash
+        self.commission_per_share = commission_per_share
+        self.commission_per_trade = commission_per_trade
+        self.spread = spread
+        self.spread_pct = spread_pct
         # Information about the currently open position. ``None`` when flat.
         self.position: dict[str, float] | None = None
         # Flag used to trigger a forced exit at the end of the session.
         self._force_exit = False
+
+    # ------------------------------------------------------------------
+    # Execution cost helpers
+    # ------------------------------------------------------------------
+    def apply_slippage(self, price: float, direction: str) -> float:
+        """Return a price adjusted for random slippage.
+
+        Parameters
+        ----------
+        price:
+            The reference price.
+        direction:
+            ``"buy"`` or ``"sell"`` indicating order side.
+        """
+
+        slippage_pct = random.uniform(0.0001, 0.0005)  # 0.01% – 0.05%
+        if direction == "buy":
+            return price * (1 + slippage_pct)
+        return price * (1 - slippage_pct)
 
     # ------------------------------------------------------------------
     # Position management helpers
@@ -53,11 +86,23 @@ class TradeSimulator:
         if self.position is not None:
             raise RuntimeError("A position is already open")
 
+        direction = "buy" if shares > 0 else "sell"
+        executed_price = self.apply_slippage(entry_price, direction)
+        spread_amt = self.spread if self.spread_pct == 0 else executed_price * self.spread_pct
+        if direction == "buy":
+            executed_price += spread_amt / 2
+        else:
+            executed_price -= spread_amt / 2
+        commission = self.commission_per_share * abs(shares) + self.commission_per_trade
+        trade_value = executed_price * shares
+        self.cash -= trade_value + commission
+
         self.position = {
-            "entry_price": float(entry_price),
+            "entry_price": float(executed_price),
             "stop_loss": float(stop_loss),
             "take_profit": float(take_profit),
             "shares": float(shares),
+            "entry_commission": commission,
         }
 
     def check_exit_conditions(self, current_price: float) -> tuple[str | None, float]:
@@ -109,7 +154,19 @@ class TradeSimulator:
         if exit_type is None or exit_price is None:
             return None, 0.0
 
-        pnl = (exit_price - entry) * shares
+        direction = "sell" if shares > 0 else "buy"
+        executed_price = self.apply_slippage(exit_price, direction)
+        spread_amt = self.spread if self.spread_pct == 0 else executed_price * self.spread_pct
+        if direction == "buy":
+            executed_price += spread_amt / 2
+        else:
+            executed_price -= spread_amt / 2
+        commission = self.commission_per_share * abs(shares) + self.commission_per_trade
+        trade_value = executed_price * (-shares)
+        self.cash -= trade_value + commission
+
+        total_commission = self.position.get("entry_commission", 0.0) + commission
+        pnl = (executed_price - entry) * shares - total_commission
         self.position = None
         self._force_exit = False
         return exit_type, pnl
@@ -120,7 +177,7 @@ class TradeSimulator:
     def simulate(self, data: pd.DataFrame, signals: pd.Series) -> pd.DataFrame:
         """Generate portfolio values from price data and signals."""
         portfolio = pd.DataFrame(index=data.index)
-        portfolio["cash"] = self.initial_cash
+        portfolio["cash"] = self.cash
         portfolio["position"] = signals.fillna(0)
         # Placeholder for actual trade execution logic
         portfolio["portfolio_value"] = portfolio["cash"]


### PR DESCRIPTION
## Summary
- model slippage with random 0.01-0.05% price adjustment
- support spread and commission costs per trade
- track cash balance and deduct costs for entries and exits

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ee3c8d4608328820caa3ef3bfb49e