### PR TITLE
Add backtest runner with summary output

### DIFF
--- a/backtest/__init__.py
+++ b/backtest/__init__.py
@@ -1,6 +1,6 @@
 """Backtesting module scaffolding."""
 
-from .backtest_engine import BacktestEngine
+from .backtest_engine import BacktestEngine, run_backtest
 from .trade_simulator import TradeSimulator
 from .metrics import (
     calculate_metrics,
@@ -11,6 +11,7 @@ from .metrics import (
 
 __all__ = [
     "BacktestEngine",
+    "run_backtest",
     "TradeSimulator",
     "calculate_metrics",
     "plot_performance",


### PR DESCRIPTION
## Summary
- implement `run_backtest` to execute event-driven backtests, print equity curve, trade log, summary metrics, and support exporting results
- expose `run_backtest` in backtest module exports

## Testing
- `python -m py_compile backtest/backtest_engine.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688eeb8aa67883289db7c4e4e56570c4