### PR TITLE
Add simple position sizing utility with tests

### DIFF
--- a/execution/position_sizer.py
+++ b/execution/position_sizer.py
@@ -1,0 +1,19 @@
+"""Utility for determining trade size based on risk management rules."""
+
+
+def calculate_position_size(equity, stop_loss_pct, current_price):
+    """Return number of shares to buy based on equity and stop loss.
+
+    Args:
+        equity: Total account equity in dollars.
+        stop_loss_pct: Stop loss distance as a decimal (e.g., 0.1 for 10%).
+        current_price: Current price of the asset.
+
+    Returns:
+        The integer number of shares to purchase. Returns 0 if calculation
+        results in a negative number of shares.
+    """
+    risk_amount = 0.01 * equity
+    stop_distance = stop_loss_pct * current_price
+    shares = int(risk_amount / stop_distance)
+    return max(shares, 0)

--- a/tests/test_position_sizer.py
+++ b/tests/test_position_sizer.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from execution.position_sizer import calculate_position_size
+
+
+def test_calculate_position_size_example():
+    """Example: $50K equity, 10% stop loss on $100 price -> 50 shares."""
+    assert calculate_position_size(50_000, 0.10, 100) == 50
+
+
+def test_calculate_position_size_negative_stop_returns_zero():
+    """Negative stop distance should result in zero shares."""
+    assert calculate_position_size(50_000, -0.05, 100) == 0


### PR DESCRIPTION
## Summary
- add `calculate_position_size` to compute trade size based on equity risk and stop distance
- cover position sizing scenarios with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688eef6eb84483288c2436310191c3a6