### PR TITLE
Add Alpaca bracket order submission utility

### DIFF
--- a/execution/order_submitter.py
+++ b/execution/order_submitter.py
@@ -1,0 +1,55 @@
+"""Utility for submitting bracket orders via the Alpaca API."""
+
+import logging
+import os
+
+from alpaca_trade_api.rest import REST
+
+logger = logging.getLogger(__name__)
+
+# Acquire credentials from environment variables, falling back to dummy strings to
+# allow initialization in environments where real credentials are unavailable
+API_KEY = os.getenv("ALPACA_API_KEY", "DUMMY")
+SECRET_KEY = os.getenv("ALPACA_SECRET_KEY", "DUMMY")
+BASE_URL = os.getenv("ALPACA_BASE_URL", "https://paper-api.alpaca.markets")
+
+# Create a reusable Alpaca REST client
+alpaca = REST(API_KEY, SECRET_KEY, BASE_URL)
+
+
+def submit_bracket_order(symbol, qty, side, entry_price, stop_pct, target_pct):
+    """Submit a market bracket order with stop-loss and take-profit.
+
+    Args:
+        symbol (str): The asset symbol to trade.
+        qty (int | float): Number of shares to trade.
+        side (str): 'buy' or 'sell'.
+        entry_price (float): The intended entry price.
+        stop_pct (float): Stop-loss percentage (e.g., 0.02 for 2%).
+        target_pct (float): Take-profit percentage (e.g., 0.05 for 5%).
+
+    Returns:
+        The order object returned by the Alpaca API.
+
+    Raises:
+        Exception: Propagates any exception from the Alpaca API.
+    """
+    stop_price = entry_price * (1 - stop_pct) if side == "buy" else entry_price * (1 + stop_pct)
+    target_price = entry_price * (1 + target_pct) if side == "buy" else entry_price * (1 - target_pct)
+
+    try:
+        order = alpaca.submit_order(
+            symbol=symbol,
+            qty=qty,
+            side=side,
+            type="market",
+            time_in_force="gtc",
+            order_class="bracket",
+            stop_loss={"stop_price": stop_price},
+            take_profit={"limit_price": target_price},
+        )
+        logger.info("Bracket order submitted: %s", order)
+        return order
+    except Exception as exc:  # pragma: no cover - network errors or others
+        logger.error("Failed to submit bracket order: %s", exc)
+        raise

--- a/tests/test_order_submitter.py
+++ b/tests/test_order_submitter.py
@@ -1,0 +1,27 @@
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from execution import order_submitter
+
+
+def test_submit_bracket_order_calls_alpaca():
+    with patch.object(order_submitter.alpaca, "submit_order", return_value="ok") as mock_submit:
+        result = order_submitter.submit_bracket_order(
+            symbol="AAPL", qty=1, side="buy", entry_price=100, stop_pct=0.05, target_pct=0.1
+        )
+    assert result == "ok"
+    stop_expected = 100 * (1 - 0.05)
+    target_expected = 100 * (1 + 0.1)
+    mock_submit.assert_called_once_with(
+        symbol="AAPL",
+        qty=1,
+        side="buy",
+        type="market",
+        time_in_force="gtc",
+        order_class="bracket",
+        stop_loss={"stop_price": stop_expected},
+        take_profit={"limit_price": target_expected},
+    )


### PR DESCRIPTION
## Summary
- add `submit_bracket_order` using Alpaca API and environment credentials
- test bracket order submission with mocked Alpaca client

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ef1e5476883288dae7f64fc1ef497