### PR TITLE
Implement volatility-based stop-loss/target calculation

### DIFF
--- a/execution/volatility_manager.py
+++ b/execution/volatility_manager.py
@@ -1,0 +1,32 @@
+"""Utilities for deriving stop-loss and take-profit levels from volatility."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def compute_stop_target(prices: pd.Series) -> tuple[float, float]:
+    """Compute stop-loss and take-profit percentages based on volatility.
+
+    The function calculates the standard deviation of the last 14 price points
+    (a simple proxy for volatility) and scales it relative to the latest price
+    to determine the stop-loss percentage. The take-profit is set to twice the
+    stop-loss value.
+
+    Args:
+        prices: Series of recent prices with the most recent price last.
+
+    Returns:
+        A tuple of ``(stop_pct, target_pct)`` where each value is expressed as
+        a decimal percentage of the latest price.
+
+    Raises:
+        ValueError: If fewer than 14 prices are supplied.
+    """
+    if len(prices) < 14:
+        raise ValueError("Need at least 14 prices to compute volatility")
+
+    atr = prices.rolling(14).std().iloc[-1]
+    stop_pct = atr / prices.iloc[-1]
+    target_pct = 2 * stop_pct
+    return stop_pct, target_pct

--- a/tests/test_volatility_manager.py
+++ b/tests/test_volatility_manager.py
@@ -1,0 +1,28 @@
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from execution.volatility_manager import compute_stop_target
+
+
+def test_compute_stop_target_returns_expected_values():
+    """Computed stop/target should match manual volatility calculation."""
+    prices = pd.Series(np.arange(1, 31))
+    stop, target = compute_stop_target(prices)
+    expected_std = np.std(np.arange(17, 31), ddof=1)
+    expected_stop = expected_std / prices.iloc[-1]
+    assert stop == pytest.approx(expected_stop)
+    assert target == pytest.approx(2 * expected_stop)
+
+
+def test_compute_stop_target_zero_volatility():
+    """Flat price series should yield zero stop and target percentages."""
+    prices = pd.Series([10] * 20)
+    stop, target = compute_stop_target(prices)
+    assert stop == 0
+    assert target == 0


### PR DESCRIPTION
## Summary
- Add `compute_stop_target` utility to derive stop-loss and take-profit percentages from recent price volatility.
- Introduce unit tests verifying expected behavior and zero-volatility edge case.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688efd319e00832881317d6ed6e606eb