### PR TITLE
Prevent overlapping orders by checking open positions

### DIFF
--- a/execution/order_submitter.py
+++ b/execution/order_submitter.py
@@ -5,6 +5,8 @@ import os
 
 from alpaca_trade_api.rest import REST
 
+from . import position_manager
+
 logger = logging.getLogger(__name__)
 
 # Acquire credentials from environment variables, falling back to dummy strings to
@@ -34,6 +36,10 @@ def submit_bracket_order(symbol, qty, side, entry_price, stop_pct, target_pct):
     Raises:
         Exception: Propagates any exception from the Alpaca API.
     """
+    if position_manager.get_open_position(symbol):
+        logger.info("Existing position for %s; skipping order", symbol)
+        return None
+
     stop_price = entry_price * (1 - stop_pct) if side == "buy" else entry_price * (1 + stop_pct)
     target_price = entry_price * (1 + target_pct) if side == "buy" else entry_price * (1 - target_pct)
 

--- a/execution/position_manager.py
+++ b/execution/position_manager.py
@@ -1,0 +1,15 @@
+import os
+from alpaca_trade_api.rest import REST, APIError
+
+API_KEY = os.getenv("ALPACA_API_KEY", "DUMMY")
+SECRET_KEY = os.getenv("ALPACA_SECRET_KEY", "DUMMY")
+BASE_URL = os.getenv("ALPACA_BASE_URL", "https://paper-api.alpaca.markets")
+
+api = REST(API_KEY, SECRET_KEY, BASE_URL)
+
+
+def get_open_position(symbol):
+    try:
+        return api.get_position(symbol)
+    except APIError:
+        return None

--- a/tests/test_order_submitter.py
+++ b/tests/test_order_submitter.py
@@ -8,10 +8,11 @@ from execution import order_submitter
 
 
 def test_submit_bracket_order_calls_alpaca():
-    with patch.object(order_submitter.alpaca, "submit_order", return_value="ok") as mock_submit:
-        result = order_submitter.submit_bracket_order(
-            symbol="AAPL", qty=1, side="buy", entry_price=100, stop_pct=0.05, target_pct=0.1
-        )
+    with patch.object(order_submitter.position_manager, "get_open_position", return_value=None):
+        with patch.object(order_submitter.alpaca, "submit_order", return_value="ok") as mock_submit:
+            result = order_submitter.submit_bracket_order(
+                symbol="AAPL", qty=1, side="buy", entry_price=100, stop_pct=0.05, target_pct=0.1
+            )
     assert result == "ok"
     stop_expected = 100 * (1 - 0.05)
     target_expected = 100 * (1 + 0.1)
@@ -25,3 +26,13 @@ def test_submit_bracket_order_calls_alpaca():
         stop_loss={"stop_price": stop_expected},
         take_profit={"limit_price": target_expected},
     )
+
+
+def test_submit_bracket_order_skips_when_position_open():
+    with patch.object(order_submitter.position_manager, "get_open_position", return_value={"symbol": "AAPL"}):
+        with patch.object(order_submitter.alpaca, "submit_order") as mock_submit:
+            result = order_submitter.submit_bracket_order(
+                symbol="AAPL", qty=1, side="buy", entry_price=100, stop_pct=0.05, target_pct=0.1
+            )
+    assert result is None
+    mock_submit.assert_not_called()


### PR DESCRIPTION
## Summary
- add position manager with helper to fetch open positions from Alpaca
- ensure submit_bracket_order skips submitting when a position for the symbol already exists
- test to confirm orders are not placed when an open position is found

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688effe35b408328aecfa41e53f15c67