### PR TITLE
Add market timer to exit positions before close

### DIFF
--- a/execution/market_timer.py
+++ b/execution/market_timer.py
@@ -1,0 +1,17 @@
+"""Market timer utilities using Alpaca's clock."""
+
+from alpaca_trade_api.rest import REST
+
+
+def should_exit_positions(api: REST) -> bool:
+    """Return ``True`` if the market is closing within five minutes.
+
+    Parameters
+    ----------
+    api:
+        Instance of ``alpaca_trade_api.rest.REST``.
+    """
+
+    clock = api.get_clock()
+    seconds_to_close = (clock.next_close - clock.timestamp).total_seconds()
+    return seconds_to_close < 300

--- a/tests/test_market_timer.py
+++ b/tests/test_market_timer.py
@@ -1,0 +1,36 @@
+"""Tests for the market timer utilities."""
+
+import os
+import sys
+from datetime import datetime, timedelta
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from execution import market_timer
+
+
+class DummyClock:
+    def __init__(self, timestamp, next_close):
+        self.timestamp = timestamp
+        self.next_close = next_close
+
+
+class DummyApi:
+    def __init__(self, clock):
+        self._clock = clock
+
+    def get_clock(self):
+        return self._clock
+
+
+def test_should_exit_positions():
+    now = datetime.utcnow()
+
+    clock_far = DummyClock(now, now + timedelta(minutes=6))
+    api_far = DummyApi(clock_far)
+    assert market_timer.should_exit_positions(api_far) is False
+
+    clock_near = DummyClock(now, now + timedelta(minutes=2))
+    api_near = DummyApi(clock_near)
+    assert market_timer.should_exit_positions(api_near) is True
+

--- a/trading_bot/run_trade_loop.py
+++ b/trading_bot/run_trade_loop.py
@@ -29,6 +29,8 @@ except Exception:  # pragma: no cover - handled gracefully in runtime
 from llm_model.sentiment_analyzer import SentimentAnalyzer
 from models.lstm_price_predictor import LSTMPricePredictor
 from utils.feature_engineering import add_technical_indicators, merge_sentiment_features
+from execution.market_timer import should_exit_positions
+from trading_app.alpaca_client import alpaca as alpaca_api
 
 
 FeatureVector = np.ndarray
@@ -116,6 +118,10 @@ def run_trade_loop(
     iterations = 0
     while max_iterations is None or iterations < max_iterations:
         iterations += 1
+
+        if should_exit_positions(alpaca_api):
+            alpaca_api.close_all_positions()
+            break
 
         price = float(price_fetcher(symbol))
         news_text = news_fetcher(symbol)


### PR DESCRIPTION
## Summary
- add `should_exit_positions` helper using Alpaca clock to detect 5-min window before market close
- integrate market timer into trading loop to close all positions when near close
- test market timer logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688effc0cf308328a98ddafa400f096f