### PR TITLE
Integrate model signals with trading loop

### DIFF
--- a/tests/test_run_trade_loop.py
+++ b/tests/test_run_trade_loop.py
@@ -1,0 +1,89 @@
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import trading_bot.run_trade_loop as rl
+
+
+class DummySentiment:
+    def get_sentiment_score(self, text):
+        return 0.0
+
+
+class DummyModel:
+    def __init__(self, input_dim):
+        pass
+
+    def load_state_dict(self, state):
+        pass
+
+    def eval(self):
+        pass
+
+    def __call__(self, x):
+        class Pred:
+            def item(self_inner):
+                return 0.6
+
+        return Pred()
+
+
+class DummyTorch:
+    float32 = None
+
+    def tensor(self, data, dtype=None):
+        return data
+
+    class no_grad:
+        def __enter__(self_inner):
+            pass
+
+        def __exit__(self_inner, exc_type, exc, tb):
+            pass
+
+
+
+def test_run_trade_loop_submits_order_on_signal():
+    with patch.object(rl, "SentimentAnalyzer", return_value=DummySentiment()):
+        with patch.object(rl, "LSTMPricePredictor", DummyModel):
+            with patch.object(rl, "torch", DummyTorch()):
+                with patch.object(rl.order_submitter, "submit_bracket_order") as mock_submit:
+                    with patch.object(rl.position_manager, "get_open_position", return_value=None):
+                        with patch.object(rl.volatility_manager, "compute_stop_target", return_value=(0.01, 0.02)):
+                            with patch.object(rl.position_sizer, "calculate_position_size", return_value=5):
+                                with patch.object(rl, "_fetch_equity", return_value=10000):
+                                    with patch.object(rl.time, "sleep", return_value=None):
+                                        rl.run_trade_loop(
+                                            symbol="AAPL",
+                                            seq_len=1,
+                                            price_fetcher=lambda s: 100.0,
+                                            news_fetcher=lambda s: "",
+                                            sleep_seconds=0.0,
+                                            max_iterations=1,
+                                            signal_threshold=0.5,
+                                        )
+    mock_submit.assert_called_once_with("AAPL", 5, "buy", 100.0, 0.01, 0.02)
+
+
+def test_run_trade_loop_skips_when_position_open():
+    with patch.object(rl, "SentimentAnalyzer", return_value=DummySentiment()):
+        with patch.object(rl, "LSTMPricePredictor", DummyModel):
+            with patch.object(rl, "torch", DummyTorch()):
+                with patch.object(rl.order_submitter, "submit_bracket_order") as mock_submit:
+                    with patch.object(rl.position_manager, "get_open_position", return_value={"symbol": "AAPL"}):
+                        with patch.object(rl.volatility_manager, "compute_stop_target", return_value=(0.01, 0.02)):
+                            with patch.object(rl.position_sizer, "calculate_position_size", return_value=5):
+                                with patch.object(rl, "_fetch_equity", return_value=10000):
+                                    with patch.object(rl.time, "sleep", return_value=None):
+                                        rl.run_trade_loop(
+                                            symbol="AAPL",
+                                            seq_len=1,
+                                            price_fetcher=lambda s: 100.0,
+                                            news_fetcher=lambda s: "",
+                                            sleep_seconds=0.0,
+                                            max_iterations=1,
+                                            signal_threshold=0.5,
+                                        )
+    mock_submit.assert_not_called()

--- a/trading_bot/run_trade_loop.py
+++ b/trading_bot/run_trade_loop.py
@@ -16,7 +16,9 @@ from __future__ import annotations
 import time
 from collections import deque
 from pathlib import Path
-from typing import Callable, Deque, Iterable, Optional
+from typing import Callable, Deque, Optional
+
+import logging
 
 import numpy as np
 import pandas as pd
@@ -26,12 +28,26 @@ try:  # pragma: no cover - torch may not be installed in some environments
 except Exception:  # pragma: no cover - handled gracefully in runtime
     torch = None  # type: ignore
 
+from execution import order_submitter, position_manager, position_sizer, volatility_manager
+
 from llm_model.sentiment_analyzer import SentimentAnalyzer
 from models.lstm_price_predictor import LSTMPricePredictor
 from utils.feature_engineering import add_technical_indicators, merge_sentiment_features
 
 
 FeatureVector = np.ndarray
+
+
+logger = logging.getLogger(__name__)
+
+
+def _fetch_equity() -> float:
+    """Return account equity using the shared Alpaca client if available."""
+    try:  # pragma: no cover - requires network in real use
+        account = order_submitter.alpaca.get_account()
+        return float(getattr(account, "equity", 0.0))
+    except Exception:
+        return 0.0
 
 
 def _default_price_fetcher(symbol: str) -> float:
@@ -77,6 +93,7 @@ def run_trade_loop(
     news_fetcher: Optional[Callable[[str], str]] = None,
     sleep_seconds: float = 60.0,
     max_iterations: Optional[int] = None,
+    signal_threshold: float = 0.5,
 ) -> None:
     """Run the main trading loop.
 
@@ -127,7 +144,7 @@ def run_trade_loop(
         # Build feature set with technical indicators and sentiment
         features_df = add_technical_indicators(price_history)
         features_df = merge_sentiment_features(features_df, sentiment_score)
-        latest = features_df.iloc[-1][
+        latest = features_df.iloc[-1].reindex(
             [
                 "close",
                 "rsi",
@@ -138,7 +155,7 @@ def run_trade_loop(
                 "volatility",
                 "sentiment",
             ]
-        ].fillna(0.0)
+        ).fillna(0.0)
 
         feature_vec = latest.to_numpy(dtype=np.float32)
         feature_window.append(feature_vec)
@@ -156,11 +173,44 @@ def run_trade_loop(
             x = torch.tensor([list(feature_window)], dtype=torch.float32)
             with torch.no_grad():
                 prediction = model(x).item()
-            action = _decide_action(prediction)
-            print(f"{symbol} price={price:.2f} pred={prediction:.4f} -> {action}")
+            action = _decide_action(prediction, threshold=signal_threshold)
+            logger.info(
+                "%s price=%.2f pred=%.4f action=%s",
+                symbol,
+                price,
+                prediction,
+                action,
+            )
+            if (
+                action != "hold"
+                and abs(prediction) >= signal_threshold
+                and position_manager.get_open_position(symbol) is None
+            ):
+                try:
+                    stop_pct, target_pct = volatility_manager.compute_stop_target(
+                        price_history["close"]
+                    )
+                except Exception:  # pragma: no cover - rely on best effort
+                    stop_pct, target_pct = 0.0, 0.0
+                equity = _fetch_equity()
+                qty = position_sizer.calculate_position_size(equity, stop_pct, price)
+                side = "buy" if action == "long" else "sell"
+                if qty > 0:
+                    order_submitter.submit_bracket_order(
+                        symbol, qty, side, price, stop_pct, target_pct
+                    )
+                logger.info(
+                    "%s price=%.2f qty=%s signal=%.4f stop=%.4f target=%.4f",
+                    symbol,
+                    price,
+                    qty,
+                    prediction,
+                    stop_pct,
+                    target_pct,
+                )
         else:
             remaining = seq_len - len(feature_window)
-            print(f"Collecting data... {remaining} minutes remaining")
+            logger.info("Collecting data... %d minutes remaining", remaining)
 
         time.sleep(sleep_seconds)
 


### PR DESCRIPTION
## Summary
- Extend trading loop to trigger live orders when model signals exceed a threshold
- Compute volatility-based stop-loss and take-profit, size positions, and log actions
- Add tests confirming bracket orders are submitted or skipped based on position state

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f033c7f248328b5ea210b576ca97d