### PR TITLE
Add droplet setup script and Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
-.PHONY: help build up down shell run
+.PHONY: help build up down shell run prepare venv
 
 help:
-	@echo "Makefile commands:"
-	@echo "  make build       - Build the Docker image using docker-compose"
-	@echo "  make up          - Start the container using docker-compose"
-	@echo "  make down        - Stop and remove the container"
-	@echo "  make shell       - Start the container and open a shell"
-	@echo "  make run SYMBOL= - Run the trading bot for a symbol (e.g., make run SYMBOL=AAPL)"
+        @echo "Makefile commands:"
+        @echo "  make build       - Build the Docker image using docker-compose"
+        @echo "  make up          - Start the container using docker-compose"
+        @echo "  make down        - Stop and remove the container"
+        @echo "  make shell       - Start the container and open a shell"
+        @echo "  make run SYMBOL= - Run the trading bot for a symbol (e.g., make run SYMBOL=AAPL)"
+        @echo "  make prepare     - Install Python 3.11 and set up a virtual environment"
+        @echo "  make venv CMD=   - Run a command inside the project's virtual environment"
 
 build:
 	docker-compose build
@@ -21,4 +23,10 @@ shell:
 	docker-compose exec trading-bot bash
 
 run:
-	 run trading-bot python cli.py alpaca $(SYMBOL)
+        run trading-bot python cli.py alpaca $(SYMBOL)
+
+prepare:
+        bash scripts/prepare_droplet.sh
+
+venv:
+        bash -c "source venv/bin/activate && $(CMD)"

--- a/README.md
+++ b/README.md
@@ -25,10 +25,26 @@ Colada is a Python-based trading toolkit that integrates real-time market data, 
    - `FINNHUB_API_KEY`
    - `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_HOST`, `MYSQL_PORT`, `MYSQL_DB`
 3. Optionally start the MySQL database and bot via Docker:
-   ```bash
-   make build
-   make up
-   ```
+    ```bash
+    make build
+    make up
+    ```
+
+### DigitalOcean droplet preparation
+
+On a fresh droplet you can install Python 3.11, create the virtual environment and install project dependencies with:
+
+```bash
+make prepare
+```
+
+To run commands inside this environment use:
+
+```bash
+make venv CMD="python cli.py alpaca AAPL"
+```
+
+Replace the command passed to `CMD` to run any script; use `bash` to drop into an interactive shell.
 
 ## Usage
 Invoke commands through the CLI:

--- a/scripts/prepare_droplet.sh
+++ b/scripts/prepare_droplet.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Setup Python 3.11 and a virtual environment for the Colada app
+set -e
+
+# Step 1: Install system build dependencies
+sudo apt update
+sudo apt install -y build-essential zlib1g-dev libncurses5-dev \
+  libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev \
+  curl libbz2-dev wget
+
+# Step 2: Download and build Python 3.11 if not already installed
+if ! command -v python3.11 >/dev/null 2>&1; then
+  cd /usr/src
+  sudo wget https://www.python.org/ftp/python/3.11.9/Python-3.11.9.tgz
+  sudo tar xzf Python-3.11.9.tgz
+  cd Python-3.11.9
+  sudo ./configure --enable-optimizations
+  sudo make -j"$(nproc)"
+  sudo make altinstall
+fi
+
+# Step 3: Verify Python 3.11 installation
+python3.11 --version
+
+# Step 4: Create and activate a virtual environment for the app
+cd "$(dirname "$0")/.."
+if [ ! -d venv ]; then
+  python3.11 -m venv venv
+fi
+source venv/bin/activate
+
+# Step 5: Upgrade pip and install Python packages
+pip install --upgrade pip setuptools wheel
+pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- script to install Python 3.11, create a venv, and install project dependencies
- Makefile targets to prepare a fresh droplet and run commands inside the venv
- documentation for preparing a DigitalOcean droplet

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fc6ba6a34832880e32458ed452bd3