### PR TITLE
Ensure SQLite support and TMPDIR in setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,26 @@ Colada is a Python-based trading toolkit that integrates real-time market data, 
 - `trading_bot/` – example LSTM trading loop using sentiment and technical features.
 
 ## Setup
-1. Install dependencies:
+1. Ensure Python 3.11 is compiled with SQLite support:
    ```bash
-   pip install -r requirements.txt
+   sudo apt install -y libsqlite3-dev
+   # If Python 3.11 was built before installing these headers, rebuild it
+   cd /usr/src/Python-3.11.9
+   sudo make clean
+   sudo ./configure --enable-optimizations
+   sudo make -j$(nproc)
+   sudo make altinstall
    ```
-2. Configure environment variables for external services:
+2. Install dependencies using a custom temporary directory to avoid `/tmp` disk space issues:
+   ```bash
+   mkdir -p ~/tmp
+   TMPDIR=~/tmp pip install -r requirements.txt
+   ```
+3. Configure environment variables for external services:
    - `ALPACA_API_KEY` / `ALPACA_SECRET_KEY`
    - `FINNHUB_API_KEY`
    - `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_HOST`, `MYSQL_PORT`, `MYSQL_DB`
-3. Optionally start the MySQL database and bot via Docker:
+4. Optionally start the MySQL database and bot via Docker:
     ```bash
     make build
     make up
@@ -32,11 +43,14 @@ Colada is a Python-based trading toolkit that integrates real-time market data, 
 
 ### DigitalOcean droplet preparation
 
-On a fresh droplet you can install Python 3.11, create the virtual environment and install project dependencies with:
+On a fresh droplet you can install Python 3.11 (with SQLite support), create the virtual environment and install project dependencies with:
 
 ```bash
 make prepare
 ```
+
+This script installs the SQLite development headers and uses a dedicated temporary
+directory during `pip install` to avoid `No space left on device` errors on small droplets.
 
 To run commands inside this environment use:
 

--- a/scripts/prepare_droplet.sh
+++ b/scripts/prepare_droplet.sh
@@ -6,14 +6,16 @@ set -e
 sudo apt update
 sudo apt install -y build-essential zlib1g-dev libncurses5-dev \
   libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev \
-  curl libbz2-dev wget
+  curl libbz2-dev wget libsqlite3-dev
 
-# Step 2: Download and build Python 3.11 if not already installed
-if ! command -v python3.11 >/dev/null 2>&1; then
+# Step 2: Download and build Python 3.11 if not already installed or missing SQLite support
+if ! command -v python3.11 >/dev/null 2>&1 || ! python3.11 -c "import sqlite3" >/dev/null 2>&1; then
   cd /usr/src
   sudo wget https://www.python.org/ftp/python/3.11.9/Python-3.11.9.tgz
+  sudo rm -rf Python-3.11.9
   sudo tar xzf Python-3.11.9.tgz
   cd Python-3.11.9
+  sudo make clean
   sudo ./configure --enable-optimizations
   sudo make -j"$(nproc)"
   sudo make altinstall
@@ -29,6 +31,7 @@ if [ ! -d venv ]; then
 fi
 source venv/bin/activate
 
-# Step 5: Upgrade pip and install Python packages
-pip install --upgrade pip setuptools wheel
-pip install -r requirements.txt
+# Step 5: Upgrade pip and install Python packages using a custom TMPDIR
+mkdir -p "$HOME/tmp"
+TMPDIR="$HOME/tmp" pip install --upgrade pip setuptools wheel
+TMPDIR="$HOME/tmp" pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- install `libsqlite3-dev` and rebuild Python if needed in droplet setup script
- use dedicated `TMPDIR` during dependency installation to avoid `/tmp` space issues
- document SQLite prerequisites and TMPDIR usage in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fd69d896c832888ad1f95639ed08e