### PR TITLE
Load environment variables from .env

### DIFF
--- a/execution/order_submitter.py
+++ b/execution/order_submitter.py
@@ -4,8 +4,11 @@ import logging
 import os
 
 from alpaca_trade_api.rest import REST
+from dotenv import load_dotenv
 
 from . import position_manager
+
+load_dotenv()
 
 logger = logging.getLogger(__name__)
 

--- a/execution/position_manager.py
+++ b/execution/position_manager.py
@@ -1,6 +1,9 @@
 import logging
 import os
 from alpaca_trade_api.rest import REST, APIError
+from dotenv import load_dotenv
+
+load_dotenv()
 
 API_KEY = os.getenv("ALPACA_API_KEY", "DUMMY")
 SECRET_KEY = os.getenv("ALPACA_SECRET_KEY", "DUMMY")

--- a/trading_app/config.py
+++ b/trading_app/config.py
@@ -1,4 +1,7 @@
 import os
+from dotenv import load_dotenv
+
+load_dotenv()
 
 ALPACA_API_KEY = os.getenv("ALPACA_API_KEY", "DUMMY")
 ALPACA_SECRET_KEY = os.getenv("ALPACA_SECRET_KEY", "DUMMY")

--- a/trading_app/models.py
+++ b/trading_app/models.py
@@ -2,6 +2,9 @@ from sqlalchemy import create_engine, Column, Integer, String, Float, DateTime
 from sqlalchemy.orm import declarative_base, sessionmaker
 from datetime import datetime
 import os
+from dotenv import load_dotenv
+
+load_dotenv()
 
 Base = declarative_base()
 


### PR DESCRIPTION
## Summary
- Use python-dotenv to load environment variables from a .env file
- Apply loading across configuration, model, and execution modules

## Testing
- `pytest -q` (fails: no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_6890520c62d88328913743e73aca7d8a