### PR TITLE
Use logging instead of print statements

### DIFF
--- a/backtest/backtest_engine.py
+++ b/backtest/backtest_engine.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from typing import Any, Callable, Sequence
+import logging
 
 import pandas as pd
 
@@ -15,6 +16,9 @@ from .metrics import (
     track_equity,
     equity_curve_dataframe,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 class BacktestEngine:
@@ -142,15 +146,13 @@ def run_backtest(
     trade_log = pd.DataFrame(_trade_log)
     summary = engine.metrics or calculate_metrics()
 
-    print("Equity Curve:")
-    print(equity.tail())
+    logger.info("Equity Curve:\n%s", equity.tail())
 
-    print("\nTrade Log:")
-    print(trade_log)
+    logger.info("\nTrade Log:\n%s", trade_log)
 
-    print("\nSummary Stats:")
+    logger.info("\nSummary Stats:")
     for key, value in summary.items():
-        print(f"{key}: {value}")
+        logger.info("%s: %s", key, value)
 
     export_path = config.get("export")
     if export_path:

--- a/models/lstm_price_predictor.py
+++ b/models/lstm_price_predictor.py
@@ -1,5 +1,6 @@
 from typing import List, Optional
 
+import logging
 import numpy as np
 import pandas as pd
 
@@ -12,6 +13,7 @@ except ImportError:  # pragma: no cover - torch may not be installed
     nn = None  # type: ignore
     Dataset = object  # type: ignore
     DataLoader = object  # type: ignore
+logger = logging.getLogger(__name__)
 
 
 class LSTMPricePredictor(nn.Module):
@@ -117,10 +119,10 @@ def train_lstm(
             optimizer.step()
             epoch_loss += loss.item() * X_batch.size(0)
         avg_loss = epoch_loss / len(dataset)
-        print(f"Epoch {epoch+1}/{num_epochs} - Loss: {avg_loss:.4f}")
+        logger.info("Epoch %s/%s - Loss: %.4f", epoch + 1, num_epochs, avg_loss)
 
     torch.save(model.state_dict(), model_path)
-    print(f"Saved model to {model_path}")
+    logger.info("Saved model to %s", model_path)
     return model
 
 

--- a/trading_app/data/collect_data.py
+++ b/trading_app/data/collect_data.py
@@ -2,10 +2,14 @@ from datetime import datetime, timedelta
 import os
 from trading_app.alpaca_client import get_historical_data
 from trading_app.indicators import TACalculator
+import logging
 
 SYMBOLS = ["AAPL", "GOOG", "MSFT"]
 OUTPUT_DIR = "data"
 DAYS = 30
+
+
+logger = logging.getLogger(__name__)
 
 
 def fetch_data(symbol):
@@ -13,11 +17,11 @@ def fetch_data(symbol):
     start = (datetime.now() - timedelta(days=DAYS + 1)).strftime("%Y-%m-%d")
     end = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
 
-    print(f"Getting data for {symbol} from: {start} and {end}")
+    logger.info("Getting data for %s from: %s and %s", symbol, start, end)
     df = get_historical_data(symbol, start, end)
 
     if df is None or df.empty:
-        print(f"No data for {symbol}")
+        logger.warning("No data for %s", symbol)
         return
 
     # Resample to 15-min
@@ -40,7 +44,7 @@ def fetch_data(symbol):
 
     os.makedirs(OUTPUT_DIR, exist_ok=True)
     df_15.to_csv(f"{OUTPUT_DIR}/{symbol}_15min.csv")
-    print(f"[Saved] {symbol} → {OUTPUT_DIR}/{symbol}_15min.csv")
+    logger.info("[Saved] %s → %s/%s_15min.csv", symbol, OUTPUT_DIR, symbol)
 
 
 def fetch_all():

--- a/trading_app/data/create_sentiment_dataset.py
+++ b/trading_app/data/create_sentiment_dataset.py
@@ -8,7 +8,9 @@ import yfinance as yf
 from llm_model.sentiment_analyzer import SentimentAnalyzer
 from trading_app.indicators import TACalculator
 from utils.feature_engineering import merge_sentiment_features
+import logging
 
+logger = logging.getLogger(__name__)
 
 def fetch_ohlcv(symbol: str, days: int = 30) -> pd.DataFrame:
     """Download 1-min OHLCV data using yfinance."""
@@ -86,4 +88,4 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     df = build_dataset(args.symbol, window=args.window, output_csv=args.output)
-    print(f"Saved {len(df)} rows to {args.output}")
+    logger.info("Saved %s rows to %s", len(df), args.output)

--- a/trading_app/data/prepare_dataset.py
+++ b/trading_app/data/prepare_dataset.py
@@ -1,4 +1,5 @@
 import os
+import logging
 import pandas as pd
 from trading_app.indicators import TACalculator
 
@@ -7,10 +8,13 @@ OUTPUT_DIR = "features"
 SYMBOLS = ["AAPL", "GOOG", "MSFT"]
 
 
+logger = logging.getLogger(__name__)
+
+
 def prepare_features(symbol):
     path = os.path.join(INPUT_DIR, f"{symbol}_15min.csv")
     if not os.path.exists(path):
-        print(f"Missing CSV for {symbol}, skipping.")
+        logger.warning("Missing CSV for %s, skipping.", symbol)
         return
 
     df = pd.read_csv(path, index_col=0, parse_dates=True)
@@ -35,7 +39,7 @@ def prepare_features(symbol):
     os.makedirs(OUTPUT_DIR, exist_ok=True)
     out_path = os.path.join(OUTPUT_DIR, f"features_{symbol}.csv")
     df.to_csv(out_path)
-    print(f"[Saved] {symbol} → {out_path}")
+    logger.info("[Saved] %s → %s", symbol, out_path)
 
 
 def prepare_all():

--- a/trading_app/finnhub_client.py
+++ b/trading_app/finnhub_client.py
@@ -1,7 +1,11 @@
 import requests
 import pandas as pd
 from datetime import datetime, timedelta
+import logging
 from .config import FINNHUB_API_KEY
+
+
+logger = logging.getLogger(__name__)
 
 
 def get_finnhub_quote(symbol):
@@ -32,7 +36,7 @@ def get_finnhub_bars(symbol, resolution=60, count=24):
     data = response.json()
 
     if data.get("s") != "ok":
-        print(f"[Finnhub Error] {data}")
+        logger.error("[Finnhub Error] %s", data)
         return None
 
     df = pd.DataFrame(

--- a/trading_app/ml/predict_symbol.py
+++ b/trading_app/ml/predict_symbol.py
@@ -1,13 +1,17 @@
 import os
+import os
+import logging
 from joblib import load
 from trading_app.finnhub_client import get_finnhub_bars
 from trading_app.indicators import TACalculator
+
+logger = logging.getLogger(__name__)
 
 
 def load_model(symbol):
     model_path = f"models/model_{symbol}.pkl"
     if not os.path.exists(model_path):
-        print(f"Model for {symbol} not found.")
+        logger.warning("Model for %s not found.", symbol)
         return None
     return load(model_path)
 
@@ -15,7 +19,7 @@ def load_model(symbol):
 def prepare_latest_features(symbol):
     df = get_finnhub_bars(symbol)
     if df is None or df.empty:
-        print(f"No data for {symbol}")
+        logger.warning("No data for %s", symbol)
         return None
 
     df = TACalculator.add_indicators(df)
@@ -26,7 +30,7 @@ def prepare_latest_features(symbol):
 
     df = df.dropna()
     if df.empty:
-        print("Insufficient data to generate features.")
+        logger.warning("Insufficient data to generate features.")
         return None
 
     latest_row = df.iloc[-1]
@@ -44,6 +48,9 @@ def predict_symbol(symbol):
 
     prediction = model.predict(features)[0]
     prob = model.predict_proba(features)[0][1]
-    print(
-        f"Prediction for {symbol}: {'UP' if prediction == 1 else 'DOWN'} (Confidence: {prob:.2f})"
+    logger.info(
+        "Prediction for %s: %s (Confidence: %.2f)",
+        symbol,
+        "UP" if prediction == 1 else "DOWN",
+        prob,
     )

--- a/trading_app/ml/train_lstm.py
+++ b/trading_app/ml/train_lstm.py
@@ -1,4 +1,5 @@
 import os
+import logging
 
 from models.lstm_price_predictor import train_lstm
 
@@ -6,13 +7,16 @@ INPUT_DIR = "features_1min"
 SYMBOLS = ["AAPL", "GOOG", "MSFT"]
 
 
+logger = logging.getLogger(__name__)
+
+
 def train_all():
     for symbol in SYMBOLS:
         path = os.path.join(INPUT_DIR, f"{symbol}.csv")
         if not os.path.exists(path):
-            print(f"Missing data for {symbol}, skipping.")
+            logger.warning("Missing data for %s, skipping.", symbol)
             continue
-        print(f"Training LSTM for {symbol} from {path}")
+        logger.info("Training LSTM for %s from %s", symbol, path)
         train_lstm(
             path,
             seq_len=60,

--- a/trading_app/ml/train_model.py
+++ b/trading_app/ml/train_model.py
@@ -1,4 +1,5 @@
 import os
+import logging
 import pandas as pd
 import xgboost as xgb
 from sklearn.model_selection import train_test_split
@@ -10,10 +11,13 @@ OUTPUT_DIR = "models"
 SYMBOLS = ["AAPL", "GOOG", "MSFT"]
 
 
+logger = logging.getLogger(__name__)
+
+
 def train_model_for_symbol(symbol):
     file_path = os.path.join(INPUT_DIR, f"features_{symbol}.csv")
     if not os.path.exists(file_path):
-        print(f"Missing features for {symbol}, skipping.")
+        logger.warning("Missing features for %s, skipping.", symbol)
         return
 
     df = pd.read_csv(file_path)
@@ -30,16 +34,16 @@ def train_model_for_symbol(symbol):
 
     y_pred = model.predict(X_test)
 
-    print(f"--- {symbol} ---")
-    print("Accuracy:", accuracy_score(y_test, y_pred))
-    print("Precision:", precision_score(y_test, y_pred))
-    print("Recall:", recall_score(y_test, y_pred))
-    print("F1 Score:", f1_score(y_test, y_pred))
-    print()
+    logger.info("--- %s ---", symbol)
+    logger.info("Accuracy: %s", accuracy_score(y_test, y_pred))
+    logger.info("Precision: %s", precision_score(y_test, y_pred))
+    logger.info("Recall: %s", recall_score(y_test, y_pred))
+    logger.info("F1 Score: %s", f1_score(y_test, y_pred))
+    logger.info("")
 
     os.makedirs(OUTPUT_DIR, exist_ok=True)
     dump(model, os.path.join(OUTPUT_DIR, f"model_{symbol}.pkl"))
-    print(f"Saved model to {OUTPUT_DIR}/model_{symbol}.pkl")
+    logger.info("Saved model to %s/model_%s.pkl", OUTPUT_DIR, symbol)
 
 
 def train_all():


### PR DESCRIPTION
## Summary
- replace `print` with `logging` across data collection, training, and backtesting modules
- add module-level loggers for consistent structured output

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68906103afb88328917783e05dce17de