### PR TITLE
feat(cli): add LSTM training command

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,10 @@ Invoke commands through the CLI:
   python cli.py collect_data
   python cli.py prepare_dataset
   ```
-- Train a model and predict a symbol:
+- Train models and predict a symbol:
   ```bash
   python cli.py train_model
+  python cli.py train_lstm
   python cli.py predict_symbol AAPL
   ```
 - Run scheduled tasks:

--- a/cli.py
+++ b/cli.py
@@ -186,6 +186,14 @@ def train_model():
 
 
 @cli.command()
+def train_lstm():
+    """Train LSTM models for all available symbols."""
+    from trading_app.ml.train_lstm import train_all
+
+    train_all()
+
+
+@cli.command()
 @click.argument("symbol")
 def predict_symbol(symbol):
     """Predict if the given symbol will go UP or DOWN using the latest model."""


### PR DESCRIPTION
## Summary
- add `train_lstm` CLI command to train LSTM models for all symbols
- document new `train_lstm` command in README

## Testing
- `pytest -q`
- `flake8` *(fails: E302 expected 2 blank lines, F811 redefinition)*

------
https://chatgpt.com/codex/tasks/task_e_6890662158748328acdf89eaee70a095