### PR TITLE
Fix flake8 warnings

### DIFF
--- a/trading_app/data/create_sentiment_dataset.py
+++ b/trading_app/data/create_sentiment_dataset.py
@@ -12,6 +12,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 def fetch_ohlcv(symbol: str, days: int = 30) -> pd.DataFrame:
     """Download 1-min OHLCV data using yfinance."""
     df = yf.download(symbol, period=f"{days}d", interval="1m", progress=False)

--- a/trading_app/ml/predict_symbol.py
+++ b/trading_app/ml/predict_symbol.py
@@ -1,5 +1,4 @@
 import os
-import os
 import logging
 from joblib import load
 from trading_app.finnhub_client import get_finnhub_bars


### PR DESCRIPTION
## Summary
- add missing blank line before `fetch_ohlcv` in dataset builder
- remove duplicated `os` import in symbol predictor

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68906901def0832880f04a79289c3033