### PR TITLE
Load trading symbols from file

### DIFF
--- a/trading_app/data/collect_data.py
+++ b/trading_app/data/collect_data.py
@@ -2,9 +2,10 @@ from datetime import datetime, timedelta
 import os
 from trading_app.alpaca_client import get_historical_data
 from trading_app.indicators import TACalculator
+from trading_app.symbols import load_symbols
 import logging
 
-SYMBOLS = ["AAPL", "GOOG", "MSFT"]
+SYMBOLS = load_symbols()
 OUTPUT_DIR = "data"
 DAYS = 30
 

--- a/trading_app/data/prepare_dataset.py
+++ b/trading_app/data/prepare_dataset.py
@@ -2,10 +2,11 @@ import os
 import logging
 import pandas as pd
 from trading_app.indicators import TACalculator
+from trading_app.symbols import load_symbols
 
 INPUT_DIR = "data"
 OUTPUT_DIR = "features"
-SYMBOLS = ["AAPL", "GOOG", "MSFT"]
+SYMBOLS = load_symbols()
 
 
 logger = logging.getLogger(__name__)

--- a/trading_app/ml/train_lstm.py
+++ b/trading_app/ml/train_lstm.py
@@ -2,9 +2,10 @@ import os
 import logging
 
 from models.lstm_price_predictor import train_lstm
+from trading_app.symbols import load_symbols
 
 INPUT_DIR = "features_1min"
-SYMBOLS = ["AAPL", "GOOG", "MSFT"]
+SYMBOLS = load_symbols()
 
 
 logger = logging.getLogger(__name__)

--- a/trading_app/ml/train_model.py
+++ b/trading_app/ml/train_model.py
@@ -5,10 +5,11 @@ import xgboost as xgb
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import accuracy_score, precision_score, recall_score, f1_score
 from joblib import dump
+from trading_app.symbols import load_symbols
 
 INPUT_DIR = "features"
 OUTPUT_DIR = "models"
-SYMBOLS = ["AAPL", "GOOG", "MSFT"]
+SYMBOLS = load_symbols()
 
 
 logger = logging.getLogger(__name__)

--- a/trading_app/symbols.py
+++ b/trading_app/symbols.py
@@ -1,0 +1,13 @@
+"""Utilities for managing trading symbols."""
+import os
+
+
+def load_symbols():
+    """Return a list of symbols defined in ``symbols.txt``.
+
+    The file is expected to contain one symbol per line and is located in the
+    same directory as this module.
+    """
+    symbols_file = os.path.join(os.path.dirname(__file__), "symbols.txt")
+    with open(symbols_file, "r", encoding="utf-8") as f:
+        return [line.strip() for line in f if line.strip()]

--- a/trading_app/symbols.txt
+++ b/trading_app/symbols.txt
@@ -1,0 +1,3 @@
+AAPL
+GOOG
+MSFT


### PR DESCRIPTION
## Summary
- store supported symbols in `symbols.txt`
- add `load_symbols` helper to read the symbols list
- use `load_symbols` instead of hard-coded symbol arrays

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68906a29080c83289304c817fb0380ae